### PR TITLE
Hotfix: Fix vendor path for Plugin Update Checker v1.3.1

### DIFF
--- a/includes/class-webp-auto-updater.php
+++ b/includes/class-webp-auto-updater.php
@@ -48,7 +48,7 @@ class WebP_Auto_Updater {
      */
     private function init_update_checker() {
         // Load the Plugin Update Checker library
-        require_once plugin_dir_path(dirname(__FILE__)) . 'vendor/plugin-update-checker/plugin-update-checker.php';
+        require_once plugin_dir_path(dirname(__FILE__)) . 'vendor/vendor/plugin-update-checker/plugin-update-checker.php';
 
         // Create the update checker instance for GitHub releases
         $this->update_checker = Puc_v4p13_Factory::buildUpdateChecker(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: webp, image, optimization, convert, media-library, bulk-processing
 Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,11 @@ Your server should be running:
 2. Side-by-side comparison of original and converted images
 
 == Changelog ==
+
+= 1.3.1 =
+* HOTFIX: Fixed incorrect vendor path for Plugin Update Checker library
+* Resolved fatal error preventing plugin activation
+* Corrected require_once path from vendor/plugin-update-checker/ to vendor/vendor/plugin-update-checker/
 
 = 1.3.0 =
 * Added GitHub-based auto-updater system using YahnisElsts Plugin Update Checker v5.6

--- a/webp-image-converter.php
+++ b/webp-image-converter.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WebP Image Converter
  * Plugin URI:        https://github.com/OrasesWPDev/webp-image-converter
  * Description:       Convert WordPress media library images to WebP format with bulk processing and optimization features.
- * Version:           1.3.0
+ * Version:           1.3.1
  * Author:            Orases
  * Author URI:        https://orases.com
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ if (!defined('WPINC')) {
 /**
  * Current plugin version.
  */
-define('WEBP_IMAGE_CONVERTER_VERSION', '1.3.0');
+define('WEBP_IMAGE_CONVERTER_VERSION', '1.3.1');
 
 /**
  * Debug flag - set to true to enable comprehensive logging


### PR DESCRIPTION
## Summary
- Fixed fatal error preventing plugin activation
- Corrected vendor library path for Plugin Update Checker
- Version increment: 1.3.0 → 1.3.1

## Problem
Plugin activation failed with fatal error:
```
Failed opening required 'vendor/plugin-update-checker/plugin-update-checker.php'
```

## Root Cause
Incorrect vendor directory structure - the plugin looked for:
- `vendor/plugin-update-checker/plugin-update-checker.php`

But the actual path was:
- `vendor/vendor/plugin-update-checker/plugin-update-checker.php`

## Changes Made
- **Fixed vendor path** in `includes/class-webp-auto-updater.php` line 51
- **Updated version** from 1.3.0 to 1.3.1 in main plugin file
- **Updated stable tag** to 1.3.1 in readme.txt
- **Added changelog** entry for hotfix

## Test Plan
- [x] Verify plugin activates successfully on local WordPress site
- [x] Confirm auto-updater functionality works after fix
- [ ] Test that GitHub Actions creates v1.3.1 release after merge

🤖 Generated with [Claude Code](https://claude.ai/code)