### PR TITLE
Fix GitHub Actions workflow - prevent unnecessary runs v1.3.2

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,13 +3,12 @@ name: Auto Release on Version Change
 on:
   push:
     branches: [ main ]
-  pull_request:
-    types: [ closed ]
-    branches: [ main ]
+    paths:
+      - 'webp-image-converter.php'
+      - 'readme.txt'
 
 jobs:
   auto-release:
-    if: github.event_name == 'push' || (github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     
     permissions:
@@ -30,21 +29,35 @@ jobs:
         echo "current_version=$VERSION" >> $GITHUB_OUTPUT
         echo "Current version detected: $VERSION"
     
-    - name: Check if version tag exists
-      id: check_tag
+    - name: Check if version changed and tag exists
+      id: check_version
       run: |
         VERSION=${{ steps.extract_version.outputs.current_version }}
+        
+        # Check if tag already exists
         if git rev-parse "v$VERSION" >/dev/null 2>&1; then
           echo "tag_exists=true" >> $GITHUB_OUTPUT
-          echo "Tag v$VERSION already exists"
+          echo "create_release=false" >> $GITHUB_OUTPUT
+          echo "⏭️  Tag v$VERSION already exists - skipping release"
+          exit 0
+        fi
+        
+        # Check if version actually changed from previous commit
+        PREVIOUS_VERSION=$(git show HEAD~1:webp-image-converter.php | awk '/\* Version:/ {print $3}' || echo "0.0.0")
+        
+        if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then
+          echo "tag_exists=false" >> $GITHUB_OUTPUT
+          echo "create_release=false" >> $GITHUB_OUTPUT
+          echo "⏭️  Version unchanged ($VERSION) - skipping release"
         else
           echo "tag_exists=false" >> $GITHUB_OUTPUT
-          echo "Tag v$VERSION does not exist - will create release"
+          echo "create_release=true" >> $GITHUB_OUTPUT
+          echo "🚀 Version changed from $PREVIOUS_VERSION to $VERSION - creating release"
         fi
     
     - name: Extract changelog for current version
       id: changelog
-      if: steps.check_tag.outputs.tag_exists == 'false'
+      if: steps.check_version.outputs.create_release == 'true'
       run: |
         VERSION=${{ steps.extract_version.outputs.current_version }}
         # Extract changelog section for current version from readme.txt
@@ -57,7 +70,7 @@ jobs:
         echo "Extracted changelog for version $VERSION"
     
     - name: Create Git tag
-      if: steps.check_tag.outputs.tag_exists == 'false'
+      if: steps.check_version.outputs.create_release == 'true'
       run: |
         VERSION=${{ steps.extract_version.outputs.current_version }}
         git config --local user.email "action@github.com"
@@ -67,7 +80,7 @@ jobs:
         echo "Created and pushed tag v$VERSION"
     
     - name: Create plugin ZIP for distribution
-      if: steps.check_tag.outputs.tag_exists == 'false'
+      if: steps.check_version.outputs.create_release == 'true'
       run: |
         # Create a clean copy of the plugin for distribution
         mkdir -p dist
@@ -82,7 +95,7 @@ jobs:
         ls -la webp-image-converter-*.zip
     
     - name: Create GitHub Release
-      if: steps.check_tag.outputs.tag_exists == 'false'
+      if: steps.check_version.outputs.create_release == 'true'
       uses: softprops/action-gh-release@v1
       with:
         tag_name: v${{ steps.extract_version.outputs.current_version }}
@@ -97,13 +110,18 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Log release completion
-      if: steps.check_tag.outputs.tag_exists == 'false'
+      if: steps.check_version.outputs.create_release == 'true'
       run: |
         echo "✅ Successfully created release v${{ steps.extract_version.outputs.current_version }}"
         echo "📦 Distribution ZIP: webp-image-converter-${{ steps.extract_version.outputs.current_version }}.zip"
         echo "🚀 WordPress sites with auto-updater will detect this release within 1 minute"
     
     - name: Skip release creation
-      if: steps.check_tag.outputs.tag_exists == 'true'
+      if: steps.check_version.outputs.create_release == 'false'
       run: |
-        echo "⏭️  Skipped release creation - tag v${{ steps.extract_version.outputs.current_version }} already exists"
+        VERSION=${{ steps.extract_version.outputs.current_version }}
+        if [ "${{ steps.check_version.outputs.tag_exists }}" = "true" ]; then
+          echo "⏭️  Skipped release creation - tag v$VERSION already exists"
+        else
+          echo "⏭️  Skipped release creation - version unchanged (v$VERSION)"
+        fi

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: webp, image, optimization, convert, media-library, bulk-processing
 Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,14 @@ Your server should be running:
 2. Side-by-side comparison of original and converted images
 
 == Changelog ==
+
+= 1.3.2 =
+* Fixed GitHub Actions workflow to prevent unnecessary runs and duplicate releases
+* Removed pull_request trigger to eliminate race conditions between PR and merge events
+* Added path filters to only run workflow when plugin files change
+* Added version change detection to skip releases when version is unchanged
+* Enhanced conditional logic and improved skip messaging
+* Reduced GitHub Actions usage and improved workflow reliability
 
 = 1.3.1 =
 * HOTFIX: Fixed incorrect vendor path for Plugin Update Checker library

--- a/webp-image-converter.php
+++ b/webp-image-converter.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WebP Image Converter
  * Plugin URI:        https://github.com/OrasesWPDev/webp-image-converter
  * Description:       Convert WordPress media library images to WebP format with bulk processing and optimization features.
- * Version:           1.3.1
+ * Version:           1.3.2
  * Author:            Orases
  * Author URI:        https://orases.com
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ if (!defined('WPINC')) {
 /**
  * Current plugin version.
  */
-define('WEBP_IMAGE_CONVERTER_VERSION', '1.3.1');
+define('WEBP_IMAGE_CONVERTER_VERSION', '1.3.2');
 
 /**
  * Debug flag - set to true to enable comprehensive logging


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow to prevent unnecessary runs and failures
- Version increment: 1.3.1 → 1.3.2
- Eliminated race conditions and duplicate release attempts

## Problems Fixed
1. **Excessive Workflow Runs**: Workflow was triggering on every PR and push, causing unnecessary builds
2. **Race Conditions**: PR trigger + merge trigger caused duplicate tag creation attempts, leading to failures like:
   ```
   error: failed to push some refs (cannot lock ref 'refs/tags/v1.3.1': reference already exists)
   ```
3. **No Version Detection**: Workflow ran even when version hadn't changed, causing failed releases
4. **Resource Waste**: Unnecessary GitHub Actions usage and cluttered logs

## Changes Made

### Trigger Improvements
- **Removed `pull_request` trigger** - eliminates race conditions entirely
- **Added path filters** - only runs when `webp-image-converter.php` or `readme.txt` change
- **Simplified to push-to-main only** - clean, predictable execution

### Version Change Detection
- **Added version comparison logic** - compares current vs previous commit version
- **Smart skip conditions** - skips if version unchanged OR tag already exists
- **Enhanced conditional logic** - uses `create_release` flag instead of just `tag_exists`

### Improved User Experience
- **Better skip messaging** - shows specific reason for skipping (version unchanged vs tag exists)
- **Cleaner logs** - no more failed tag push attempts
- **Reliable releases** - only creates releases when actually needed

## Test Plan
- [x] Version updated to 1.3.2 to trigger workflow
- [x] Workflow will only run when this PR merges to main (not on PR creation)
- [ ] Verify workflow creates v1.3.2 release successfully
- [ ] Confirm future commits without version changes skip workflow

## Expected Behavior After Merge
✅ **This merge will trigger the workflow** (version changed 1.3.1 → 1.3.2)  
✅ **Future non-version commits will skip** (workflow won't run)  
✅ **No more duplicate tag errors** (eliminated race conditions)  

🤖 Generated with [Claude Code](https://claude.ai/code)